### PR TITLE
keep after arrival & ignore driving

### DIFF
--- a/v2sim/sim_core.py
+++ b/v2sim/sim_core.py
@@ -91,6 +91,7 @@ def get_sim_params(
             "copy_state":           args.pop_bool("copy-state"),
             "route_algo":           args.pop_str("route-algo", "CH"),
             "static_routing":       args.pop_bool("static-routing"),
+            "ignore_driving":       args.pop_bool("ignore-driving"),
         }
     if check_illegal and len(args) > 0:
         for key in args.keys():
@@ -140,6 +141,7 @@ class V2SimInstance:
         copy_state: bool = False,
         route_algo: str = "CH",
         static_routing: bool = False,
+        ignore_driving: bool = False,
     ):
         '''
         Initialization
@@ -306,6 +308,7 @@ class V2SimInstance:
             initial_state_folder = initial_state,
             routing_algo = route_algo,
             force_static_routing=static_routing,
+            ignore_driving=ignore_driving,
         )
 
         # Enable plugins


### PR DESCRIPTION
1. Provide the ignore driving option for improving speed, with a performance improvement of up to 5% on a case of 10000 vehicles in 12 nodes.
+ The more vehicles driving simultaneously, the greater the performance improvement.
+ This option no longer dynamically updates the battery level during vehicle driving, but updates it all at once at the end of the trip.
+ When this option is enabled, the charging station cannot be rerouted after it is turned off, which may result in uncertain behavior.
+ When this option is enabled, it will not automatically transmit when the battery is depleted. Please ensure that the vehicle's battery is sufficient.
2. Introduce keep after arrival, so that the electricity generated by the last driving distance before the vehicle arrives can also be correctly counted.
3. Advance the departure operation to the beginning of the single step simulation to prevent errors caused by entering the simulation again before the vehicle disappears after the keep after arrival.